### PR TITLE
Fix modal overlay layout

### DIFF
--- a/assets/css/catalog.css
+++ b/assets/css/catalog.css
@@ -226,6 +226,14 @@
   border-radius: var(--wpb-img-radius);
 }
 
+/* Container for thumbnails */
+.wpb-gallery {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--wpb-img-spacing);
+  margin-bottom: 1rem;
+}
+
 /* Lightbox styles */
 .wpb-lightbox {
   display:none;
@@ -244,6 +252,11 @@
 }
 .modal-backdrop {
   z-index:1070;
+  background-color:#000;
+  opacity:0.8 !important;
+}
+body.modal-open {
+  overflow: hidden;
 }
 .wpb-lightbox img {
   max-width:90%;

--- a/assets/js/catalog.js
+++ b/assets/js/catalog.js
@@ -1,4 +1,6 @@
 jQuery(document).ready(function($){
+    // Ensure modals are attached to <body> so the backdrop covers everything
+    $('.wpb-service .modal').appendTo('body');
     $('.wpb-booking-form').each(function(){
         var form = $(this);
         var steps = form.find('.wpb-step');

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -712,14 +712,16 @@ class WP_Plugin_Booking {
 
             if ( $gallery ) {
                 $ids = array_filter( array_map( 'absint', explode( ',', $gallery ) ) );
+                echo '<div class="wpb-gallery d-flex flex-wrap mb-3">';
                 foreach ( $ids as $img_id ) {
                     $thumb = wp_get_attachment_image_src( $img_id, 'medium' );
                     $full  = wp_get_attachment_image_src( $img_id, 'large' );
                     if ( $thumb ) {
-                        $full_url  = $full ? $full[0] : $thumb[0];
+                        $full_url = $full ? $full[0] : $thumb[0];
                         echo '<img src="' . esc_url( $thumb[0] ) . '" data-full="' . esc_url( $full_url ) . '" class="wpb-gallery-thumb wpb-expand-image" />';
                     }
                 }
+                echo '</div>';
             }
             if ( $video ) {
                 $embed = wp_oembed_get( esc_url( $video ) );


### PR DESCRIPTION
## Summary
- ensure modals attach to `<body>` for full-screen backdrop
- darken and stabilize bootstrap backdrop
- prevent background scrolling while modal is open
- arrange gallery thumbnails in a flexible grid

## Testing
- `npm test --silent` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_686c0febbb54832cae6323a14527f27c