### PR TITLE
Improve catalog layout

### DIFF
--- a/assets/css/catalog.css
+++ b/assets/css/catalog.css
@@ -139,9 +139,9 @@
 
 .wpb-catalog {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  grid-template-columns: 1fr;
   gap: 2rem;
-  max-width: 1200px;
+  max-width: 1000px;
   margin: 0 auto;
   padding: 2rem 5% 4rem;
   opacity: 0;
@@ -162,10 +162,17 @@
   transform: translateY(-8px);
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.12);
 }
-.wpb-service .card-img-top {
+.service-horizontal {
+  display: flex;
+  align-items: center;
+}
+.service-img {
+  width: 40%;
   height: 180px;
   object-fit: cover;
-  border-bottom: 1px solid #f0f0f0;
+}
+.service-horizontal .card-body {
+  flex: 1;
 }
 .wpb-price {
   font-weight: bold;
@@ -407,31 +414,10 @@ body.modal-open {
 
 /* Two column catalog layout */
 .wpb-container {
-  display: flex;
-  gap: 1.5rem;
-  align-items: flex-start;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 5%;
 }
-.wpb-sidebar {
-  background: #f1f1f1;
-  padding: 1rem;
-  border-radius: 8px;
-  min-width: 200px;
-}
-.category-menu { list-style: none; padding: 0; margin: 0; }
-.category-link {
-  border: none;
-  background: transparent;
-  width: 100%;
-  text-align: left;
-  padding: .5rem .75rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: #333;
-  border-radius: 4px;
-}
-.category-link:hover,
-.category-link.active { background: #e0e0e0; }
 .cart-btn { position: relative; color: #2c3e50; }
 .cart-count {
   position: absolute;
@@ -447,11 +433,11 @@ body.modal-open {
 .wpb-filters input { min-width: 150px; }
 @media (max-width:768px){
   .wpb-container{flex-direction:column;}
-  .wpb-sidebar{width:100%;}
 }
 
 .wpb-footer{
   background:#0d47a1;
   color:#fff;
+  padding:20px 0;
 }
 

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -696,17 +696,6 @@ class WP_Plugin_Booking {
         echo '<main class="wpb-main">';
         echo '<div class="wpb-container">';
 
-        $terms = get_terms( array( 'taxonomy' => 'wpb_service_category', 'hide_empty' => false ) );
-        echo '<aside class="wpb-sidebar"><form method="get"><ul class="category-menu">';
-        $active = $category ? $category : 0;
-        $sel    = 0 === $active ? ' active' : '';
-        echo '<li><button class="category-link' . $sel . '" type="submit" name="category" value=""> <i class="fas fa-list me-2"></i>' . esc_html__( 'Todas', 'wp-plugin-booking' ) . '<span class="float-end"><i class="fas fa-chevron-right"></i></span></button></li>';
-        foreach ( $terms as $term ) {
-            $sel = $active === $term->term_id ? ' active' : '';
-            echo '<li><button class="category-link' . $sel . '" type="submit" name="category" value="' . esc_attr( $term->term_id ) . '"><i class="fas fa-map-marker-alt me-2"></i>' . esc_html( $term->name ) . '<span class="float-end"><i class="fas fa-chevron-right"></i></span></button></li>';
-        }
-        echo '</ul></form></aside>';
-
         echo '<div class="wpb-content">';
         echo '<form class="wpb-filters d-flex flex-wrap align-items-center mb-3" method="get">';
         echo '<input type="hidden" name="category" value="' . esc_attr( $category ) . '" />';
@@ -731,11 +720,11 @@ class WP_Plugin_Booking {
            $rating    = floatval( get_post_meta( $id, '_wpb_rating', true ) );
            $discount  = floatval( get_post_meta( $id, '_wpb_discount_percent', true ) );
            $disc_min  = absint( get_post_meta( $id, '_wpb_discount_min', true ) );
-           echo '<div class="col-md-6 col-lg-4 mb-4 wpb-service">';
-           echo '<div class="card service-card rounded-4 h-100">';
+           echo '<div class="col-12 mb-4 wpb-service">';
+           echo '<div class="card service-card service-horizontal rounded-4 overflow-hidden">';
 
-            echo get_the_post_thumbnail( $id, 'medium', array( 'class' => 'card-img-top' ) );
-            echo '<div class="card-body d-flex flex-column">';
+            echo get_the_post_thumbnail( $id, 'medium', array( 'class' => 'service-img' ) );
+            echo '<div class="card-body d-flex flex-column justify-content-between">';
             if ( $cats && ! is_wp_error( $cats ) ) {
                 $first = $cats[0];
                 echo '<span class="badge bg-secondary mb-2">' . esc_html( $first->name ) . '</span>';
@@ -948,20 +937,11 @@ class WP_Plugin_Booking {
         echo '</div>'; // wpb-container
         echo '</section>';
 
-        $premium_title = get_option( 'wpb_premium_title', '✨ Servicios Premium ✨' );
-        $premium_text  = get_option( 'wpb_premium_text', '¿Buscas algo completamente personalizado? Nuestro equipo diseña experiencias únicas para ti.' );
         $phone  = get_option( 'wpb_contact_phone', '+1 (555) 123-4567' );
         $email  = get_option( 'wpb_contact_email', 'info@paraisoturistico.com' );
         $url    = get_option( 'wpb_contact_url', 'https://www.paraisoturistico.com' );
-        echo '<div class="premium-banner p-5 text-center">';
-        echo '<h2 class="premium-title mb-3">' . esc_html( $premium_title ) . '</h2>';
-        echo '<p class="premium-text mb-4">' . esc_html( $premium_text ) . '</p>';
-        echo '<div class="row justify-content-center g-3">';
-        echo '<div class="col-md-4"><div class="contact-item"><i class="fas fa-phone"></i><span>' . esc_html( $phone ) . '</span></div></div>';
-        echo '<div class="col-md-4"><div class="contact-item"><i class="fas fa-envelope"></i><span>' . esc_html( $email ) . '</span></div></div>';
-        echo '<div class="col-md-4"><div class="contact-item"><i class="fas fa-globe"></i><span>' . esc_html( $url ) . '</span></div></div>';
-        echo '</div></div>';
-        echo '<footer class="wpb-footer text-center text-white mt-5 p-4">';
+        echo '<footer class="wpb-footer text-center text-white p-4">';
+        echo '<p class="mb-2"><i class="fas fa-phone me-1"></i>' . esc_html( $phone ) . ' | <i class="fas fa-envelope me-1"></i>' . esc_html( $email ) . ' | <i class="fas fa-globe me-1"></i>' . esc_html( $url ) . '</p>';
         echo '<p class="mb-0">&copy; ' . date( 'Y' ) . ' ' . esc_html( $logo ) . '</p>';
         echo '</footer>';
         echo '</main>';


### PR DESCRIPTION
## Summary
- simplify catalog by removing sidebar and premium banner
- add responsive horizontal service cards
- update footer with contact info
- clean up catalog CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c29d6f058832c99b5429c632dbd8c