### PR TITLE
Improve catalog layout and header

### DIFF
--- a/assets/css/catalog.css
+++ b/assets/css/catalog.css
@@ -366,10 +366,10 @@
   align-items:center;
 }
 .modal {
-  z-index:1080;
+  z-index:1100;
 }
 .modal-backdrop {
-  z-index:1070;
+  z-index:1090;
   background-color:#000;
   opacity:0.8 !important;
 }
@@ -511,7 +511,7 @@ body.modal-open {
 
 /* Two column catalog layout */
 .wpb-container {
-  max-width: 1200px;
+  max-width: 1400px;
   margin: 0 auto;
   padding: 0 5%;
 }
@@ -530,6 +530,20 @@ body.modal-open {
 .wpb-filters input { min-width: 150px; }
 @media (max-width:768px){
   .wpb-container{flex-direction:column;}
+}
+
+@media (min-width:1200px){
+  .wpb-catalog .wpb-service{
+    flex:0 0 20%;
+    max-width:20%;
+  }
+}
+
+@media (max-width:576px){
+  .wpb-catalog .wpb-service{
+    flex:0 0 100%;
+    max-width:100%;
+  }
 }
 
 .wpb-footer{

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -691,18 +691,17 @@ class WP_Plugin_Booking {
         ob_start();
         $logo = get_option( 'wpb_front_title', 'Aventura Tours' );
         echo '<header class="wpb-header"><nav><div class="logo">' . esc_html( $logo ) . '</div>';
-        echo '<form method="get" class="header-search me-auto"><input type="text" name="s" value="' . esc_attr( $search ) . '" placeholder="' . esc_attr__( 'Buscar...', 'wp-plugin-booking' ) . '" /></form>';
-        echo '<a href="' . esc_url( wp_login_url() ) . '" class="btn btn-light login-btn">' . esc_html__( 'Ingresar', 'wp-plugin-booking' ) . '</a></nav></header>';
+        if ( is_user_logged_in() ) {
+            $current_user = wp_get_current_user();
+            echo '<span class="text-white ms-auto">' . sprintf( esc_html__( 'Hola, %s', 'wp-plugin-booking' ), esc_html( $current_user->display_name ) ) . '</span>';
+        } else {
+            echo '<a href="' . esc_url( wp_login_url() ) . '" class="btn btn-light login-btn ms-auto"><i class="fas fa-sign-in-alt me-1"></i>Login In</a>';
+        }
+        echo '</nav></header>';
         echo '<main class="wpb-main">';
         echo '<div class="wpb-container">';
 
         echo '<div class="wpb-content">';
-        echo '<form class="wpb-filters d-flex flex-wrap align-items-center mb-3" method="get">';
-        echo '<input type="hidden" name="category" value="' . esc_attr( $category ) . '" />';
-        echo '<div class="me-2 flex-grow-1"><input type="text" name="s" value="' . esc_attr( $search ) . '" class="form-control" placeholder="' . esc_attr__( 'Buscar...', 'wp-plugin-booking' ) . '"></div>';
-        echo '<div class="me-2"><select name="orderby" class="form-select"><option value="">' . esc_html__( 'Ordenar por', 'wp-plugin-booking' ) . '</option><option value="name"' . selected( $orderby, 'name', false ) . '>' . esc_html__( 'Nombre', 'wp-plugin-booking' ) . '</option><option value="price"' . selected( $orderby, 'price', false ) . '>' . esc_html__( 'Precio', 'wp-plugin-booking' ) . '</option><option value="category"' . selected( $orderby, 'category', false ) . '>' . esc_html__( 'Categoría', 'wp-plugin-booking' ) . '</option></select></div>';
-        echo '<button class="btn btn-danger">' . esc_html__( 'Filtrar', 'wp-plugin-booking' ) . '</button>';
-        echo '</form>';
 
         echo '<div class="row wpb-catalog">';
         while ( $query->have_posts() ) {


### PR DESCRIPTION
## Summary
- update login button to show icon or greeting
- remove search/filter markup
- widen container and make 5 cards per row on large screens
- fix modal z-index

## Testing
- `php -l includes/class-wp-plugin-booking.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c39cae534832c8923002647729ac8