### PR TITLE
Fix modal z-index and update card grid

### DIFF
--- a/assets/css/catalog.css
+++ b/assets/css/catalog.css
@@ -376,6 +376,9 @@
 body.modal-open {
   overflow: hidden;
 }
+.swal2-container {
+  z-index: 2000 !important;
+}
 .wpb-lightbox img {
   max-width:90%;
   max-height:90%;
@@ -534,12 +537,12 @@ body.modal-open {
 
 @media (min-width:1200px){
   .wpb-catalog .wpb-service{
-    flex:0 0 20%;
-    max-width:20%;
+    flex:0 0 25%;
+    max-width:25%;
   }
 }
 
-@media (max-width:576px){
+@media (max-width:767.98px){
   .wpb-catalog .wpb-service{
     flex:0 0 100%;
     max-width:100%;

--- a/assets/js/catalog.js
+++ b/assets/js/catalog.js
@@ -96,6 +96,11 @@ jQuery(document).ready(function($){
 
             $.post(wpbCatalog.ajax_url, form.serialize(), function(response){
                 if(response.success){
+                    var modalEl = form.closest('.modal')[0];
+                    if(modalEl){
+                        var instance = bootstrap.Modal.getInstance(modalEl);
+                        if(instance){ instance.hide(); }
+                    }
                     Swal.fire({
                         icon: 'success',
                         title: '¡Reserva realizada con éxito!'

--- a/includes/class-wp-plugin-booking.php
+++ b/includes/class-wp-plugin-booking.php
@@ -720,7 +720,7 @@ class WP_Plugin_Booking {
            $discount  = floatval( get_post_meta( $id, '_wpb_discount_percent', true ) );
            $disc_min  = absint( get_post_meta( $id, '_wpb_discount_min', true ) );
            $image_url = get_the_post_thumbnail_url( $id, 'large' );
-           echo '<div class="col-md-6 col-lg-4 mb-4 wpb-service">';
+           echo '<div class="col-md-6 col-lg-4 col-xl-3 mb-4 wpb-service">';
            echo '<div class="hotel-card" style="background-image:linear-gradient(rgba(0,0,0,0.3), rgba(0,0,0,0.5)), url(' . esc_url( $image_url ) . ');">';
 
             if ( $price ) {


### PR DESCRIPTION
## Summary
- ensure SweetAlert confirmation appears above any Bootstrap modal
- make service cards layout 4-per-row on xl screens
- adjust responsive behavior for mobile widths

## Testing
- `php -l includes/class-wp-plugin-booking.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686c3fe3ae1c832c99c0046d7a2f928a